### PR TITLE
Economy game QoL improvements, fixes and new commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /venv/
 config.json
 /DEV/logging_example.py
+*.pyc

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -37,7 +37,7 @@ class Admin(commands.Cog):
     @commands.Cog.listener()
     async def on_raw_message_delete(self, payload):
         message = payload.cached_message
-        if message.channel.name != 'bot-logs' and not message.content.startswith('$') and message.author.id != 775808657199333376:
+        if message.channel.name != 'bot-logs' and not message.content.startswith('$') and message.author.id != helper.get_config('bot_discord_uid'):
             em = discord.Embed(title='Message Deletion:', colour=0xff0000)
             em.add_field(name='Author', value='{0}'.format(message.author), inline=False)
             em.add_field(name='Channel', value='{0}'.format(message.channel), inline=False)

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -1767,7 +1767,10 @@ class Deck:
         current_i_display_names = self.current_display_names[:]
         current_i_display_names[self.current_card_idx] = f' ▶ {self.current_display_names[self.current_card_idx]}'
         for idx, name in enumerate(current_i_display_names):
-            current_i_display_names[idx] = f'{current_i_display_names[idx]} x{self.current_card_counts[idx]}'
+            if self.current_card_counts[idx] > 1:
+                current_i_display_names[idx] = f'{current_i_display_names[idx]} ({self.current_card_counts[idx]}x {self.current_display_code[idx]})'
+            else:
+                current_i_display_names[idx] = f'{current_i_display_names[idx]} ({self.current_display_code[idx]})'
         card_names_string = '\n'.join(current_i_display_names)
 
         embed = discord.Embed(title='Set', description=self.current_set_name, colour=self.ctx.author.colour)

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -712,10 +712,6 @@ class Economy(commands.Cog):
                            helper.get_config('porg_stab_emoji'),
                            helper.get_config('sid_smile_emoji'),
                            helper.get_config('gray_squadron_emoji')]
-        symbol_string = '\n'.join(slot_emoji_list)
-        action_emoji_list = ['🕹️', '💰', '⬅', '➡', '🛑']
-        action_list = '\n'.join(['Spin!', 'Cash out current net', 'Previous Machine', 'Next Machine', 'Quit.'])
-        control_string = '\n'.join(action_emoji_list)
         info_emoji_list = ['⬅', '➡', '🛑']
         stop = False
 
@@ -762,21 +758,22 @@ class Economy(commands.Cog):
             info_string = 'Medals'
             rewards_string = ''
             for idx in range(1, 10):
-                reward = selected_rewards.get(idx)
-                rewards_string += f'{reward}\n'
+                rewards_string += '{}: {}\n'.format(slot_emoji_list[idx-1], selected_rewards.get(idx))
             new_embed = discord.Embed(title='Slot Machine Info!', description='Your personal guide to gambling.',
                                       colour=0xFFFF)
             new_embed.add_field(name='Slot Type', value=machine_name, inline=True)
             new_embed.add_field(name='Cost', value=selected_info.get('cost') * selected_info.get('max_spin'),
                                 inline=True)
             new_embed.add_field(name='Major Jackpot', value=selected_info.get('major_jackpot'), inline=True)
-            new_embed.add_field(name='Symbol', value=symbol_string, inline=True)
-            new_embed.add_field(name='Reward', value=rewards_string, inline=True)
+            new_embed.add_field(name='Rewards', value=rewards_string, inline=False)
             new_embed.add_field(name='Bonuses',
                                 value='Any 2 sabers to x2 that spin!\nAny 3 sabers to x5 that spin!\nGet 3 Gray Symbols for JACKPOT!',
                                 inline=False)
-            new_embed.add_field(name='Controls', value=control_string, inline=True)
-            new_embed.add_field(name='Action', value=action_list, inline=True)
+            new_embed.add_field(name='Actions', value='🕹️: Spin!\n' 
+                                                      '💰: Cash out current net\n'
+                                                      '⬅: Previous Machine\n'
+                                                      '➡: Next Machine\n'
+                                                      '🛑: Quit', inline=False)
             new_embed.add_field(name='Future updates to include:', value=info_string, inline=False)
             new_embed.set_footer(text='Help Hotline: 1-800-522-4700')
             return new_embed

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -1957,12 +1957,11 @@ class Shop:
                 item_name = item_name.replace('Faction', self.economy.current_faction)
             elif item_name == 'Random Affiliation':
                 item_name = item_name.replace('Affiliation', self.economy.current_affiliation)
-            item_name_list.append(f"{item_dict.get('emoji')} {item_quantity:,}x{item_name}")
-            item_cost_list.append(f"{helper.credits_to_string(item_dict.get('cost'))}")
-            item_code_list.append(f"{item_dict.get('item_code')}")
-        embed.add_field(name='Item', value='\n'.join(item_name_list))
-        embed.add_field(name='Cost', value='\n'.join(item_cost_list))
-        embed.add_field(name='Code', value='\n'.join(item_code_list))
+            embed.add_field(name='{} {}x {} ({})'.format(item_dict.get('emoji'), 
+                                                         item_quantity,
+                                                         item_code,
+                                                         helper.credits_to_string(item_dict.get('cost'))), 
+                            value='{}'.format(item_name), inline=False)
         _, time_left = await self.economy.check_cd(self.economy.bot_discord_uid, 'RESTOCK')
         _, time_left_minor = await self.economy.check_cd(self.economy.bot_discord_uid, 'RESTOCK_MINOR')
         major_text = 'Restocking' if time_left < datetime.timedelta(0) else str(time_left).split('.')[0]

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -301,11 +301,11 @@ class Economy(commands.Cog):
             if 'HOPE' in message.content.upper().replace(' ', ''):
                 cd, _ = await self.check_cd(discord_uid, 'HOPE')
                 if cd:
-                    await message.add_reaction('<:rebel:761887570656231434>')
+                    await message.add_reaction(helper.get_config('rebel_emoji'))
                     await self.change_credits(discord_uid, self.credit_msg_reward)
                     await self.set_cd(discord_uid, 'HOPE', 'MI', 30)
             if 'VAPOR' in message.content.upper().replace(' ', ''):
-                await message.add_reaction('<:SidSmile:768524163505061918>')
+                await message.add_reaction(helper.get_config('sid_smile_emoji'))
 
     # Commands
     @commands.command()
@@ -459,8 +459,10 @@ class Economy(commands.Cog):
         elif two_credits_total < wager:
             await ctx.send(f'{opponent.mention} only has {two_credits_total} credits.')
         else:
-            emoji_list = ['<:swblaster:763109456774430821>', '<:sabergreen:839526247113555998>',
-                          '<:SidSmile:768524163505061918>', '🏃']
+            emoji_list = [helper.get_config('blaster_emoji'), 
+                          helper.get_config('saber_green_emoji'),
+                          helper.get_config('sid_smile_emoji'), 
+                          '🏃']
 
             async def duel_helper(one: discord.Member, two: discord.Member, emojis, b_count):
                 msg = await one.send(f'Dueling against {two.display_name} for {b_count} credits!'
@@ -649,11 +651,15 @@ class Economy(commands.Cog):
     @commands.command(aliases=['slots_info'])
     async def slot_info(self, ctx):
         """Information on the slot machine"""
-        slot_emoji_list = ['<:saberwhite:839526247209500712>',
-                           '<:saberred:839526247108575272>', '<:saberpurple:839526247159037982>',
-                           '<:saberblue:839526247146848284>', '<:sabergreen:839526247113555998>',
-                           '<:swblaster:763109456774430821>', '<:PorgStab:761886195432423474>',
-                           '<:SidSmile:768524163505061918>', '<:GraySquadron:761887065448251412>']
+        slot_emoji_list = [helper.get_config('saber_white_emoji'),
+                           helper.get_config('saber_red_emoji'),
+                           helper.get_config('saber_purple_emoji'),
+                           helper.get_config('saber_blue_emoji'),
+                           helper.get_config('saber_green_emoji'),
+                           helper.get_config('blaster_emoji'),
+                           helper.get_config('porg_stab_emoji'),
+                           helper.get_config('sid_smile_emoji'),
+                           helper.get_config('gray_squadron_emoji')]
         symbol_string = '\n'.join(slot_emoji_list)
         action_emoji_list = ['🕹️', '💰', '⬅', '➡', '🛑']
         action_list = '\n'.join(['Spin!', 'Cash out current net', 'Previous Machine', 'Next Machine', 'Quit.'])
@@ -1227,11 +1233,16 @@ class Economy(commands.Cog):
 
 class SlotMachine:
     # TODO: Han Solo Machine
-    slot_emoji_list = ['<a:sw_slot:839526247255375892>', '<:saberwhite:839526247209500712>',
-                       '<:saberred:839526247108575272>', '<:saberpurple:839526247159037982>',
-                       '<:saberblue:839526247146848284>', '<:sabergreen:839526247113555998>',
-                       '<:swblaster:763109456774430821>', '<:PorgStab:761886195432423474>',
-                       '<:SidSmile:768524163505061918>', '<:GraySquadron:761887065448251412>']
+    slot_emoji_list = [helper.get_config('slot_emoji'),
+                       helper.get_config('saber_white_emoji'),
+                       helper.get_config('saber_red_emoji'),
+                       helper.get_config('saber_purple_emoji'),
+                       helper.get_config('saber_blue_emoji'),
+                       helper.get_config('saber_green_emoji'),
+                       helper.get_config('blaster_emoji'),
+                       helper.get_config('porg_stab_emoji'),
+                       helper.get_config('sid_smile_emoji'),
+                       helper.get_config('gray_squadron_emoji')]
     # Black, Red, Yellow, Green, Black
     state_list = [['SLOT IDLE', 0x000000], ['YOU LOST', 0xFF0800], ['SPINNING', 0xFFF700],
                   ['YOU WIN', 0x2EFF00], ['CLOSED', 0x000000]]

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -361,15 +361,15 @@ class Economy(commands.Cog):
                 if cd:
                     header_state = 'now'
                     prize = random.randint(1, 5) * lotto_type[4] * self.credit_msg_reward
-                    result_string += f'\n{display_name} won {prize:,.0f} credits from their {lotto_type[3]}!'
+                    result_string += f'\n{display_name} won {helper.credits_to_string(prize)} from their {lotto_type[3]}!'
                     prize_total += prize
                     await self.set_cd(discord_uid, lotto_type[0], lotto_type[1], lotto_type[2])
                 else:
                     cd_string += f"\n{lotto_type[3]}: {str(time_left).split('.')[0]}"
             await self.change_credits(discord_uid, prize_total - 1)
             await self.change_credits(self.bot_discord_uid, 1)
-            header_string = f'{ctx.author.mention} {header_state} has {credits_total + prize_total - self.lotto_cost:,.0f} credits!'
-            footer_string = f'Lotto cost: {self.lotto_cost} C'
+            header_string = f'{ctx.author.mention} {header_state} has {helper.credits_to_string(credits_total + prize_total - self.lotto_cost)}!'
+            footer_string = f'Lotto cost: {helper.credits_to_string(self.lotto_cost)}'
 
             embed = discord.Embed(title="Lotto Results", description=header_string, colour=ctx.author.colour)
             embed.set_thumbnail(
@@ -439,10 +439,10 @@ class Economy(commands.Cog):
                     _, _, tax_rate = self.credits_tier(giver_total)
                     give_count = math.ceil(count * (1 - tax_rate)) - 5
                     tax_count = count - give_count
-                    message = f'{ctx.author.mention} have gifted {member.mention} {count:,} credits! '
+                    message = f'{ctx.author.mention} have gifted {member.mention} {helper.credits_to_string(count)}! '
                     if reason is not None:
                         message += f'\nMemo: {reason}'
-                    message += f'\n{tax_count:,} credits were withheld for handling fees.'
+                    message += f'\n{helper.credits_to_string(tax_count)} were withheld for handling fees.'
                     await ctx.send(message)
                     await self.change_credits(giver, -1 * count)
                     await self.change_credits(taker, give_count)
@@ -493,9 +493,9 @@ class Economy(commands.Cog):
         one_credits_total = await self.get_credits(ctx.author.id)
         two_credits_total = await self.get_credits(opponent.id)
         if one_credits_total < wager:
-            await ctx.send(f'{ctx.author.mention} only has {one_credits_total} credits.')
+            await ctx.send(f'{ctx.author.mention} only has {helper.credits_to_string(one_credits_total)}.')
         elif two_credits_total < wager:
-            await ctx.send(f'{opponent.mention} only has {two_credits_total} credits.')
+            await ctx.send(f'{opponent.mention} only has {helper.credits_to_string(two_credits_total)}.')
         else:
             emoji_list = [helper.get_config('blaster_emoji'), 
                           helper.get_config('saber_green_emoji'),
@@ -503,7 +503,7 @@ class Economy(commands.Cog):
                           '🏃']
 
             async def duel_helper(one: discord.Member, two: discord.Member, emojis, b_count):
-                msg = await one.send(f'Dueling against {two.display_name} for {b_count} credits!'
+                msg = await one.send(f'Dueling against {two.display_name} for {helper.credits_to_string(b_count)}!'
                                      f'\nPlease select one of the below emojis!'
                                      f'\n(Response is final, you cannot change after submission.)'
                                      f'\nBlaster < Saber < Force < Blaster'
@@ -610,18 +610,18 @@ class Economy(commands.Cog):
                     print('This is not in the result matrix.')
                 await self.change_credits(self.bot_discord_uid, (2 * tax))
                 coin_string1 = f'{one_name}\n{two_name}'
-                coin_string2 = f'{one_credits_total:,} > {one_credits_total - wager:,} -> {await self.get_credits(ctx.author.id):,} C' \
-                               f'\n{two_credits_total:,} > {two_credits_total - wager:,} -> {await self.get_credits(opponent.id):,} C'
+                coin_string2 = f'{helper.credits_to_string(one_credits_total)} > {helper.credits_to_string(one_credits_total - wager)} -> {helper.credits_to_string(await self.get_credits(ctx.author.id))}' \
+                               f'\n{helper.credits_to_string(two_credits_total)} > {helper.credits_to_string(two_credits_total - wager)} -> {helper.credits_to_string(await self.get_credits(opponent.id))}'
             embed = discord.Embed(title="Duel Results", description=result_string, colour=em_color)
             embed.set_thumbnail(url=em_avatar)
             embed.add_field(name='Aggressor', value=f'{ctx.author.mention}', inline=True)
             embed.add_field(name='~V.S~', value=f'{one_r}v{two_r}', inline=True)
             embed.add_field(name='Defender', value=f'{opponent.mention}', inline=True)
             if not str(result)[-1] == '9' and not str(result)[:1] == '0':
-                embed.add_field(name='__Prize__', value=f'{2 * prize:,} C', inline=False)
+                embed.add_field(name='__Prize__', value=f'{helper.credits_to_string(2 * prize)}', inline=False)
                 embed.add_field(name='__Name__', value=coin_string1, inline=True)
                 embed.add_field(name='__Change__', value=coin_string2, inline=True)
-            embed.set_footer(text=f'Cleaner Fee: {2 * tax} C')
+            embed.set_footer(text=f'Cleaner Fee: {helper.credits_to_string(2 * tax)}')
             await ctx.send(embed=embed)
 
     @duel.error
@@ -1037,7 +1037,7 @@ class Economy(commands.Cog):
                 embed.set_author(name=user.display_name, icon_url=user.avatar_url)
                 embed.add_field(name='Total cards', value=total_cards)
                 embed.add_field(name='Completion', value='{}/{}'.format(unique_cards, self.card_count))
-                embed.add_field(name='Value', value=f'{deck_value:,}', inline=False)
+                embed.add_field(name='Value', value=f'{helper.credits_to_string(deck_value)}', inline=False)
                 embed.add_field(name='Affiliations', value='Heroes: {} ({}/{})\n'
                                                            'Neutrals: {} ({}/{})\n'
                                                            'Villains: {} ({}/{})\n'
@@ -1645,7 +1645,7 @@ class SlotMachine:
                 sith_penalty = math.floor(self.player_credits_total*.1) if self.selected_machine_name == 'SITH REVENGE' else 0
                 await self.add_jackpot(self.selected_machine_name, int((self.epic_fail + sith_penalty) / 100))
                 await casino_channel.send(
-                    f'{sid}{sid} {self.author.mention} LOST TO THE HIGHGROUND! -{self.epic_fail*self.multi + sith_penalty:,} Credits! {sid}{sid}')
+                    f'{sid}{sid} {self.author.mention} LOST TO THE HIGHGROUND! -{helper.credits_to_string(self.epic_fail*self.multi + sith_penalty)}! {sid}{sid}')
             # GRAY
             elif epic > 0 and self.win_bool:
                 await self.cash_out(self.current_jackpot[epic - 1], 0, epic)
@@ -1653,9 +1653,9 @@ class SlotMachine:
                 self.player_credits_total += self.current_jackpot[epic - 1]
                 if epic == 3:
                     await casino_channel.send(
-                        f'💰💰 @here {self.author.mention} WON THE JACKPOT OF {self.current_jackpot[epic - 1]:,}! 💰💰')
+                        f'💰💰 @here {self.author.mention} WON THE JACKPOT OF {helper.credits_to_string(self.current_jackpot[epic - 1])}! 💰💰')
                 elif epic == 2:
-                    await self.ctx.send(f'You won the minor jackpot of {self.current_jackpot[epic-1]:,}!', delete_after=600)
+                    await self.ctx.send(f'You won the minor jackpot of {helper.credits_to_string(self.current_jackpot[epic-1])}!', delete_after=600)
 
     async def slot_reaction_waiter(self) -> str:
         """Async helper to await for reactions"""
@@ -1683,21 +1683,21 @@ class SlotMachine:
         result_string = f'-- {slot_state} --'
         embed = discord.Embed(title=f'**LVL {self.machine_level} {self.selected_machine_name} x{self.multi}**',
                               description=f'EXP: {self.machine_exp} / {self.next_exp:.0f}'
-                                          f'\nMajor Jackpot: {self.current_jackpot[2]:,}'
-                                          f'\nMinor Jackpot: {self.current_jackpot[1]:,}'
-                                          f'\nBonus: {self.current_jackpot[0]:,}',
+                                          f'\nMajor Jackpot: {helper.credits_to_string(self.current_jackpot[2])}'
+                                          f'\nMinor Jackpot: {helper.credits_to_string(self.current_jackpot[1])}'
+                                          f'\nBonus: {helper.credits_to_string(self.current_jackpot[0])}',
                               color=slot_color)
         embed.set_author(name=self.author.display_name, icon_url=self.author.avatar_url)
         embed.set_thumbnail(url=self.selected_machine_icon)
         embed.add_field(name='------------------', value=slot_string, inline=False)
         embed.add_field(name='------------------', value=result_string, inline=False)
-        embed.add_field(name='Profit', value=str(self.profit), inline=True)
+        embed.add_field(name='Profit', value=f'{helper.credits_to_string(self.profit)}', inline=True)
         embed.add_field(name='Multi', value=porg_string, inline=True)
         embed.add_field(name='CardBonus', value=f'x{1+self.bonus/100:.2f}', inline=True)
         embed.add_field(name='Spins', value=str(self.spins_left), inline=True)
-        embed.add_field(name='Wallet', value=f'{self.player_credits_total:,} C', inline=True)
+        embed.add_field(name='Wallet', value=f'{helper.credits_to_string(self.player_credits_total)}', inline=True)
         embed.set_footer(
-            text=f'Play Cost: {self.selected_machine_cost*self.multi:,}\nConfused? $slot_info\nTime: %s'
+            text=f'Play Cost: {helper.credits_to_string(self.selected_machine_cost*self.multi)}\nConfused? $slot_info\nTime: %s'
                  % datetime.datetime.now().strftime('%Y-%b-%d %H:%M:%S'))
         return embed
 
@@ -1944,7 +1944,7 @@ class Shop:
             elif item_name == 'Random Affiliation':
                 item_name = item_name.replace('Affiliation', self.economy.current_affiliation)
             item_name_list.append(f"{item_dict.get('emoji')} {item_quantity:,}x{item_name}")
-            item_cost_list.append(f"{item_dict.get('cost'):,}")
+            item_cost_list.append(f"{helper.credits_to_string(item_dict.get('cost'))}")
             item_code_list.append(f"{item_dict.get('item_code')}")
         embed.add_field(name='Item', value='\n'.join(item_name_list))
         embed.add_field(name='Cost', value='\n'.join(item_cost_list))
@@ -2332,7 +2332,7 @@ class EconomyLB(menus.ListPageSource):
         if fields is None:
             fields = []
         len_data = len(self.entries)
-        embed = discord.Embed(title="Leaderboard", description="Galactic Points", colour=self.ctx.author.colour)
+        embed = discord.Embed(title="Leaderboard", description="Galactic Credits", colour=self.ctx.author.colour)
         embed.set_thumbnail(url='https://media.discordapp.net/attachments/800431166997790790/840009740855934996/gray_squadron_logo.png')
         embed.set_footer(text=f"{offset:,} - {min(len_data, offset+self.per_page-1):,} of {len_data:,}.")
         for name, value in fields:
@@ -2352,7 +2352,7 @@ class EconomyLB(menus.ListPageSource):
 
         offset = (menu.current_page * self.per_page) + 1
         fields = []
-        table = "\n".join(f"{get_rank(idx+offset)}. {self.ctx.guild.get_member(entry[0]).display_name} - {entry[1]:,} Points" for idx, entry in enumerate(entries))
+        table = "\n".join(f"{get_rank(idx+offset)}. {self.ctx.guild.get_member(entry[0]).display_name} - {helper.credits_to_string(entry[1])}" for idx, entry in enumerate(entries))
         fields.append(("Rank", table))
         return await self.write_page(offset, fields)
 

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -485,8 +485,22 @@ class Economy(commands.Cog):
 
     @commands.command()
     @commands.cooldown(rate=1, per=30, type=commands.BucketType.user)
-    async def duel(self, ctx, opponent: discord.Member, wager: int):
-        """Duel a specific user for x credits"""
+    async def duel(self, ctx, opponent: discord.Member, amount: str):
+        """Duel a specific user for x credits
+        Usage:
+        $duel @user amount
+
+        Example:
+        $duel @user 500
+        $duel @user 10k
+        $duel @user 1.2M"""
+        wager = 0
+        try:
+            wager = helper.parse_amount(amount)
+        except ValueError:
+            await ctx.send('Invalid argument: {}\nType "$help duel" for more info.'.format(amount))
+            return
+
         if ctx.author.id == opponent.id:
             await ctx.send('You cannot duel yourself.')
             return

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -1740,9 +1740,16 @@ class Deck:
         self.set_list = sorted(list(self.db_select_dict.keys()))
         self.current_set_code = self.set_list[self.current_set_idx]
         self.current_set_dict = self.db_select_dict.get(self.set_list[self.current_set_idx])
-        self.sent_embed = await self.ctx.send(embed=await self.generate_deck_embed())
-        for e in Deck.deck_action_emoji_list:
-            await self.sent_embed.add_reaction(e)
+
+        # If there's only one card to show, show directly the card embed without reactions
+        self.get_current_deck_info()
+        if len(self.user_deck_dict.keys()) == 1:
+            self.is_card = 1
+            self.sent_embed = await self.ctx.send(embed=await self.generate_card_embed())
+        else:
+            self.sent_embed = await self.ctx.send(embed=await self.generate_deck_embed())
+            for e in Deck.deck_action_emoji_list:
+                await self.sent_embed.add_reaction(e)
 
     def get_current_deck_info(self):
         keys = self.current_set_dict.keys()
@@ -1757,7 +1764,6 @@ class Deck:
 
     async def generate_deck_embed(self) -> discord.Embed:
         """Generate embed that shows entire deck by set"""
-        self.get_current_deck_info()
         current_i_display_names = self.current_display_names[:]
         current_i_display_names[self.current_card_idx] = f' ▶ {self.current_display_names[self.current_card_idx]}'
         for idx, name in enumerate(current_i_display_names):
@@ -1953,7 +1959,7 @@ class Deck:
             await self.open()
             await self.close_out()
         else:
-            await self.ctx.send('You have no cards.')
+            await self.ctx.send('No cards found.')
 
 
 class EconomyLB(menus.ListPageSource):

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -477,7 +477,8 @@ class Economy(commands.Cog):
                 'SELECT DISTINCT rarity_code FROM gray.sw_card_db ORDER BY 1'
                ) AS ct (discord_uid bigint, "C" int, "L" int, "R" int, "S" int, "U" int) 
    
-                RIGHT JOIN gray.rpginfo AS rpginfo on ct.discord_uid = rpginfo.discord_uid ORDER BY "TOTAL" DESC;""")
+                RIGHT JOIN gray.rpginfo AS rpginfo on ct.discord_uid = rpginfo.discord_uid 
+                WHERE rpginfo.discord_uid <> $1 ORDER BY "TOTAL" DESC;""", self.bot_discord_uid)
         menu = menus.MenuPages(source=EconomyLB(ctx, value_lb), clear_reactions_after=True)
         await menu.start(ctx)
         await ctx.message.delete()
@@ -2339,9 +2340,19 @@ class EconomyLB(menus.ListPageSource):
         return embed
 
     async def format_page(self, menu, entries):
+        def get_rank(idx: int) -> str:
+            if idx == 1:
+                return '🥇'
+            elif idx == 2:
+                return '🥈'
+            elif idx == 3:
+                return '🥉'
+            else:
+                return '{}'.format(idx)
+
         offset = (menu.current_page * self.per_page) + 1
         fields = []
-        table = "\n".join(f"{idx+offset}. {self.ctx.guild.get_member(entry[0]).display_name} - {entry[1]:,} Points" for idx, entry in enumerate(entries))
+        table = "\n".join(f"{get_rank(idx+offset)}. {self.ctx.guild.get_member(entry[0]).display_name} - {entry[1]:,} Points" for idx, entry in enumerate(entries))
         fields.append(("Rank", table))
         return await self.write_page(offset, fields)
 

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -197,15 +197,14 @@ class Economy(commands.Cog):
 
         card_codes, card_names = await get_cards(base_string, rarity, quantity)
 
-        # Check if got enough cards
-        while len(card_codes) != quantity:
-            # If exhausted pool
-            if rarity == 'S':
-                for remaining in range(0, quantity - len(card_codes)):
-                    card_codes.extend([random.choice(card_codes)])
-                break
-            rarity = self.card_rarity_list[self.card_rarity_list.index(rarity) - 1]
-            card_codes.extend(await get_cards(base_string, rarity, quantity - len(card_codes)))
+        # If not enough cards, try all the rarity from S to L until we have enough cards
+        if len(card_codes) != quantity:
+            for new_rarity in self.card_rarity_list:
+                new_card_codes, new_card_names = await get_cards(base_string, new_rarity, quantity - len(card_codes))
+                card_codes.extend(new_card_codes)
+                card_names.extend(new_card_names)
+                if len(card_codes) == quantity:
+                    break;
 
         return card_codes, card_names
 

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -1719,7 +1719,7 @@ class Deck:
                     return
 
                 db_select_record = await connection.fetch(
-                    """SELECT set_code, * FROM gray.sw_card_db WHERE code = ANY($1::text[])""", card_list)
+                    """SELECT set_code, code, * FROM gray.sw_card_db WHERE code = ANY($1::text[])""", card_list)
                 self.db_select_dict = {}
                 for record in db_select_record:
                     set_code = ''

--- a/utils/helper.py
+++ b/utils/helper.py
@@ -59,3 +59,20 @@ def record_to_dict(f_record, key_name: str):
                 except KeyError:
                     return_dict[key] = {f: v}
     return return_dict
+
+def join_with_and(values) -> str:
+    """Same as ', '.join() but with ' and ' between the last 2 values"""
+    valuesList = list(values)
+    length = len(valuesList)
+
+    # value1, value2, value3 and value4
+    if length > 2:
+        return ', '.join(valuesList[:-1]) + " and " + str(valuesList[-1])
+    # value1 and value2
+    elif length == 2:
+        return ' and '.join(valuesList)
+    # value 1
+    elif length == 1:
+        return valuesList[0]
+    # Empty
+    return ''

--- a/utils/helper.py
+++ b/utils/helper.py
@@ -161,3 +161,27 @@ def parse_amount(amount: str) -> int:
         return int(amount)
     else:
         return int(float(amount[:len(amount)-1])*10**exp)
+
+def credits_to_string(amount: int) -> str:
+    letter = ''
+    divider = 1
+    absAmount = abs(amount)
+    if absAmount >= 10**15:
+        letter = 'Q'
+        divider = 10**15
+    elif absAmount >= 10**12:
+        letter = 'T'
+        divider = 10**12
+    elif absAmount >= 10**9:
+        letter = 'B'
+        divider = 10**9
+    elif absAmount >= 10**6:
+        letter = 'M'
+        divider = 10**6
+        
+    if divider == 1:
+        return '{:,} C'.format(int(amount))
+    if amount >= 10**18:
+        return '{:,} {}C'.format(int(amount / divider), letter)
+    else:
+        return '{:.3g} {}C'.format(amount / divider, letter)

--- a/utils/helper.py
+++ b/utils/helper.py
@@ -141,3 +141,23 @@ async def parse_input_args_filters(ctx, commands, args) -> (discord.Member, bool
         raise ValueError('Invalid arguments. Use either \"all\" or affiliation/rarity name but not both.')
 
     return user, has_all, affiliation_codes, rarity_codes, card_codes
+
+def parse_amount(amount: str) -> int:
+    """Parses the amount that can be either and integer, or something like "10k", "1.2M", etc..."""
+    amountLowerCase = amount.lower()
+    exp = 0
+    if amountLowerCase.endswith('k'):
+        exp = 3
+    elif amountLowerCase.endswith('m'):
+        exp = 6
+    elif amountLowerCase.endswith('b'):
+        exp = 9
+    elif amountLowerCase.endswith('t'):
+        exp = 12
+    elif amountLowerCase.endswith('q'):
+        exp = 15
+
+    if exp == 0:
+        return int(amount)
+    else:
+        return int(float(amount[:len(amount)-1])*10**exp)


### PR DESCRIPTION
Changelog:
$slot command:
- Added slot multiplier for each level (x1, x3, x10, x30, x100, x300…). Removed x10 and x100 reactions, multiplier is always applied.
- When typing "$slot", the first machine to open is the last one played by the user
- Moved "Card Bonus" to the header, added "Total" value (Profit x Multi x Card Bonus)

$buy command:
- Added "all" and "cpx" arguments. "$buy all" will buy all the cards (cp1-cp5, cpa, cpf and cps), where "$buy cpx" will buy all the cp1-cp5 cards. If you don't have enough money to buy everything, it will buy as many cards as possible in the order of the shop.
- Fixed "$buy cpf" and "$buy cps" crashes

$deck command:
- Added filters by affiliations, rarity and card codes. Affiliation and rarity can be used together (Ex: "$deck villain legendary", or simply "$deck v l")
- Added "missing" argument to show the cards you don't have, can be used with filters too. (Ex: "$deck missing hero" or "$deck missing h")
- Card code is displayed in the list of cards
- If there's only one card to show, show directly the card instead of the list

$send_card and $request_card commands:
- $trade_card command has been renamed $request_card and a new $send_card command has been added. The $send_card command doesn't need any confirmation from the reciever
- Both commands can transfer one card with the card code as before (Ex: "$send_card @user 01001"), but also a list of cards (Ex: "$send_card @user 01001 01002 01003"), transfer all the cards matching the affiliation/rarity filters (Ex: "$send_card @user neutral starters" or "$send_card @user n s") or even transfer the entire deck (Ex: "$send_card @user all")

$transfer and $duel commands:
- The amount for transfer and duel can be specified using k, M, B, T and Q suffixes, like "$transfer @user 10k" or "$duel @user 1.2M". (Not case sensitive)

$bal command:
- Added @user optional argument to see another user's info
- Added deck value and total

$lb command:
- Added medal emoji for top 3
- Removed bot from leaderboard

$shop:
- Reworked to display correctly on mobile

$slot_info:
- Reworked to display correctly on mobile

$deck_stats command:
- New command to show some statistics about your deck or the deck from another user

$who_has_card command:
- New command to know who has the specified card number in his deck (Ex: $who_has_card 01001)

Global:
- Reworked the way credits amount are displayed, numbers bigger than 1 million use 3 significant digits (except in $bal command)

Note: Add this to config.json to deploy:

   "bot_discord_uid": 775808657199333376,
   "slot_emoji": "<a:sw_slot:839526247255375892>",
   "rebel_emoji": "<:rebel:761887570656231434>",
   "saber_white_emoji": "<:saberwhite:839526247209500712>",
   "saber_red_emoji": "<:saberred:839526247108575272>",
   "saber_purple_emoji": "<:saberpurple:839526247159037982>",
   "saber_blue_emoji": "<:saberblue:839526247146848284>",
   "saber_green_emoji": "<:sabergreen:839526247113555998>",
   "blaster_emoji": "<:swblaster:763109456774430821>",
   "porg_stab_emoji": "<:PorgStab:761886195432423474>",
   "sid_smile_emoji": "<:SidSmile:768524163505061918>",
   "gray_squadron_emoji": "<:GraySquadron:761887065448251412>"