### PR TITLE
Hotfixes from pull request #1 and new features

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -501,7 +501,7 @@ class Admin(commands.Cog):
             print(error)
 
     @commands.command()
-    @commands.has_any_role('Droid Engineer', 'Cdt')
+    @commands.has_any_role('Droid Engineer', 'Cadet')
     async def get_mentor(self, ctx, mentee: discord.Member = None):
         """Get mentor for self or specified user"""
         if mentee is None:

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -194,7 +194,11 @@ class Admin(commands.Cog):
             await bot_commands_channel.send(
                 f'Nickname for {member.display_name} is too long at {len(after_nick)} characters!')
         else:
-            await member.edit(nick=after_nick)
+            try:
+                await member.edit(nick=after_nick)
+            except:
+                print('Error in update_nick for member:', member.display_name)
+
 
     @commands.command()
     @commands.has_role('Active')

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -162,7 +162,7 @@ class Admin(commands.Cog):
     async def update_member_nick(self, ctx, member: discord.Member = None):
         """Manual prefix update on nickname"""
         prefix, fo_num = '', ''
-        if ctx is not None:
+        if member is None:
             member = ctx.author
         member_roles = member.roles
         guild_roles = member.guild.roles
@@ -199,13 +199,9 @@ class Admin(commands.Cog):
             except:
                 print('Error in update_nick for member:', member.display_name)
 
-
     @commands.command()
-    @commands.has_role('Active')
-    @commands.has_any_role('Droid Engineer', 'Commander', 'Captain', 'Lieutenant', 'Flight Officer')
-    async def claim(self, ctx, new_fo: int):
-        """Claim a FO #"""
-        user_id = ctx.author.id
+    @commands.has_any_role('Droid Engineer', 'Commander', 'Captain', 'Lieutenant')
+    async def set_fo(self, ctx, user: discord.Member, new_fo: int):
         general_channel = discord.utils.get(ctx.guild.text_channels, name='general')
         previous_id = await helper.get_roster(self, 'discord_uid', new_fo)
         if new_fo == 420:
@@ -213,24 +209,37 @@ class Admin(commands.Cog):
         else:
             if previous_id == 0:
                 # Remove other claims of FO before assignment
-                prev_fo = await helper.get_roster(self, 'fo', user_id)
+                prev_fo = await helper.get_roster(self, 'fo', user.id)
                 if prev_fo is not None:
                     await helper.set_fo(self, prev_fo, 0)
-                    await general_channel.send(f'FO {prev_fo} has opened up!')
+                    await general_channel.send(f'Number {prev_fo} has opened up!')
                 # Claim FO
-                await helper.set_fo(self, new_fo, user_id)
-                await general_channel.send(f'{ctx.author.mention} has claimed FO {new_fo}!')
-                await self.update_member_nick(ctx)
+                await helper.set_fo(self, new_fo, user.id)
+                if user.id == ctx.author.id:
+                    await general_channel.send(f'{user.mention} has claimed number {new_fo}!')
+                else:
+                    await ctx.send(f'Number {new_fo} assigned to {user.mention}')
+                await self.update_member_nick(ctx, user)
                 await self.update_roster()
-            elif previous_id == user_id:
-                await ctx.send(f'{ctx.author.mention}, you already own FO {new_fo}!')
+            elif previous_id == user.id:
+                if user.id == ctx.author.id:
+                    await ctx.send(f'{user.mention}, you already own number {new_fo}!')
+                else:
+                    await ctx.send(f'{user.mention} already owns number {new_fo}!')
             elif previous_id is None:
-                await ctx.send(f'That is not a registered FO number!')
+                await ctx.send(f'That is not a registered number!')
             elif previous_id != 0:
                 previous_member = ctx.guild.get_member(previous_id)
-                await ctx.send(f'FO {new_fo} is already claimed by {previous_member.nick}!')
+                await ctx.send(f'Number {new_fo} is already assigned to {previous_member.nick}!')
             else:
                 await ctx.send(f'You found a bug in the claim command!')
+
+    @commands.command()
+    @commands.has_role('Active')
+    @commands.has_any_role('Droid Engineer', 'Commander', 'Captain', 'Lieutenant', 'Flight Officer')
+    async def claim(self, ctx, new_fo: int):
+        """Claim a FO #"""
+        await self.set_fo(ctx, ctx.author, new_fo)
 
     @claim.error
     async def claim_error(self, ctx, error):

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -1171,17 +1171,30 @@ class Economy(commands.Cog):
 
             async def request_card_helper() -> str:
                 msg = None
+                affiliations_string = helper.join_with_and(affiliation_names, 'or')
+                rarities_string = helper.join_with_and([self.card_rarity_name_dict[rarity_code] for rarity_code in rarity_codes], 'or')
                 if request_all:
-                    msg = await user.send(f'{ctx.author.display_name} is requesting all your cards ({total_card_quantity} cards)')
+                    msg = await user.send('{} is requesting all your cards ({} cards)'.format(ctx.author.display_name, total_card_quantity))
                 elif affiliation_names and rarity_codes:
-                    msg = await user.send(f'{ctx.author.display_name} is requesting all your {self.card_rarity_name_dict[rarity_codes].lower()} {affiliation_names} cards ({total_card_quantity} cards)')
+                    msg = await user.send('{} is requesting all your cards from rarity {} and affiliation {} ({} cards)'
+                        .format(ctx.author.display_name, 
+                            rarities_string,
+                            affiliations_string,
+                            total_card_quantity))
                 elif affiliation_names:
-                    msg = await user.send(f'{ctx.author.display_name} is requesting all your {affiliation_names} cards ({total_card_quantity} cards)')
+                    msg = await user.send('{} is requesting all your cards from affiliation {} ({} cards)'
+                        .format(ctx.author.display_name,
+                            affiliations_string,
+                            total_card_quantity))
                 elif rarity_codes:
-                    msg = await user.send(f'{ctx.author.display_name} is requesting all your {rarity_codes} cards ({total_card_quantity} cards)')
+                    msg = await user.send('{} is requesting all your cards from rarity {} ({} cards)'
+                        .format(ctx.author.display_name,
+                            rarities_string,
+                            total_card_quantity))
                 elif card_codes:
-                    msg = await user.send('{} is requesting card(s): {}'.format(ctx.author.display_name, helper.join_with_and('{} ({}{})'.format(
-                        card['name'], 
+                    msg = await user.send('{} is requesting card(s): {}'
+                        .format(ctx.author.display_name, 
+                            helper.join_with_and('{} ({}{})'.format(card['name'], 
                         '{}x '.format(card_codes.count(card['code'])) if card_codes.count(card['code']) > 1 else '', 
                         card['code']) for card in cards_records)))
                 for emoji in trade_emojis:

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -398,10 +398,11 @@ class Economy(commands.Cog):
         embed = discord.Embed(title=f"{tax_bracket_string} Wallet", colour=ctx.author.colour)
         embed.set_author(name=user.display_name, icon_url=user.avatar_url)
         embed.set_thumbnail(url=img_link)
-        embed.add_field(name='Wallet', value=f'{credit_total:,} C'
-                        f'\nTax Rate: {tax_rate * 100:.1f}%', inline=False)
-        embed.add_field(name='Deck value', value=f'{deck_value:,} C', inline=False)
-        embed.add_field(name='Total', value=f'{(deck_value + credit_total):,} C', inline=False)
+        embed.add_field(name='Wallet', value='{}\nTax Rate: {:.1f}%'.format(
+                                              helper.credits_to_string_with_exact_value(credit_total, '\n'),
+                                              tax_rate * 100), inline=False)
+        embed.add_field(name='Deck value', value=helper.credits_to_string_with_exact_value(deck_value, '\n'), inline=False)
+        embed.add_field(name='Total', value=helper.credits_to_string_with_exact_value(deck_value + credit_total, '\n'), inline=False)
         # TODO: Stats on wallet growth
         await ctx.send(embed=embed)
 

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -2473,11 +2473,11 @@ class EconomyLB(menus.ListPageSource):
             elif idx == 3:
                 return '🥉'
             else:
-                return '{}'.format(idx)
+                return '{}.'.format(idx)
 
         offset = (menu.current_page * self.per_page) + 1
         fields = []
-        table = "\n".join(f"{get_rank(idx+offset)}. {self.ctx.guild.get_member(entry[0]).display_name} - {helper.credits_to_string(entry[1])}" for idx, entry in enumerate(entries))
+        table = "\n".join(f"{get_rank(idx+offset)} {self.ctx.guild.get_member(entry[0]).display_name} - {helper.credits_to_string(entry[1])}" for idx, entry in enumerate(entries))
         fields.append(("Rank", table))
         return await self.write_page(offset, fields)
 

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -412,7 +412,7 @@ class Economy(commands.Cog):
         await self.change_credits(user.id, count)
 
     @commands.command()
-    @commands.cooldown(rate=1, per=5, type=commands.BucketType.user)
+    @commands.cooldown(rate=1, per=30, type=commands.BucketType.user)
     async def transfer(self, ctx, member: discord.Member, amount: str, *, reason: str = None):
         """Transfer credits to another user.
         Examples: 

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -1444,7 +1444,7 @@ class Economy(commands.Cog):
                     user_quantity_strings = []
                     for entry in uid_count_record:
                         member = await ctx.guild.fetch_member(entry['discord_uid'])
-                        user_quantity_strings.append('{} ({}x)'.format(member, entry['count']))
+                        user_quantity_strings.append('{} ({}x)'.format(member.display_name, entry['count']))
                     if len(user_quantity_strings) == 1:
                         await ctx.send('{} has the card you\'re looking for!'.format(helper.join_with_and(user_quantity_strings)))
                     else:

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -297,7 +297,7 @@ class Economy(commands.Cog):
             bracket = 'silver5'
         elif credits_total < 24_414_062_500:
             bracket = 'silver6'
-        elif credits_total < 122_070_312_500:
+        else:
             bracket = 'silver7'
         img_link = coin_tier.get(bracket)[0]
         tax_rate = coin_tier.get(bracket)[1]

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -2018,6 +2018,7 @@ class Shop:
                                                          item_code,
                                                          helper.credits_to_string(item_dict.get('cost'))), 
                             value='{}'.format(item_name), inline=False)
+        embed.add_field(name='Wallet', value=helper.credits_to_string(await self.economy.get_credits(self.author.id)))
         _, time_left = await self.economy.check_cd(self.economy.bot_discord_uid, 'RESTOCK')
         _, time_left_minor = await self.economy.check_cd(self.economy.bot_discord_uid, 'RESTOCK_MINOR')
         major_text = 'Restocking' if time_left < datetime.timedelta(0) else str(time_left).split('.')[0]

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -2529,8 +2529,9 @@ class DeckStats:
                         for rarity_count in rarity_count_record:
                             deck_value += self.economy.card_rarity_value[rarity_count['rarity_code']] * rarity_count['sum']
 
+                        total = 0 if total_unique_record[0]['total'] is None else total_unique_record[0]['total']
                         # Build global embed
-                        self.pages['Global'] = await self.generate_global_embed(total_unique_record[0]['total'], total_unique_record[0]['unique'], max_unique, deck_value)
+                        self.pages['Global'] = await self.generate_global_embed(total, total_unique_record[0]['unique'], max_unique, deck_value)
                     else:
                         key = self.pages_to_key.get(page)
                         user_total_unique_record = await connection.fetch(
@@ -2585,7 +2586,7 @@ class DeckStats:
         embed.add_field(name='Completion{} '.format(' ✅' if unique == max_unique else ''), 
             value='{:.1f}%\n{:,}/{:,}'.format(unique / max_unique * 100, unique, max_unique), inline=False)
         embed.add_field(name='Deck value', value='{}'.format(helper.credits_to_string_with_exact_value(deck_value, '\n')), inline=False)
-        embed.add_field(name='Average card value', value='{}'.format(helper.credits_to_string_with_exact_value(int(deck_value / total), '\n')), inline=False)
+        embed.add_field(name='Average card value', value='{}'.format(helper.credits_to_string_with_exact_value(int(deck_value / total), '\n') if total > 0 else 'N/D'), inline=False)
         embed.set_footer(text=f'Page 1/{len(self.pages)}')
         return embed        
 

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -415,7 +415,7 @@ class Economy(commands.Cog):
         await self.change_credits(user.id, count)
 
     @commands.command()
-    @commands.cooldown(rate=1, per=30, type=commands.BucketType.user)
+    @commands.cooldown(rate=1, per=5, type=commands.BucketType.user)
     async def transfer(self, ctx, member: discord.Member, amount: str, *, reason: str = None):
         """Transfer credits to another user.
         Examples: 
@@ -438,7 +438,7 @@ class Economy(commands.Cog):
                     _, _, tax_rate = self.credits_tier(giver_total)
                     give_count = math.ceil(count * (1 - tax_rate)) - 5
                     tax_count = count - give_count
-                    message = f'{ctx.author.mention} have gifted {member.mention} {helper.credits_to_string(count)}! '
+                    message = f'{ctx.author.mention} has gifted {member.mention} {helper.credits_to_string_with_exact_value(count)}! '
                     if reason is not None:
                         message += f'\nMemo: {reason}'
                     message += f'\n{helper.credits_to_string(tax_count)} were withheld for handling fees.'
@@ -447,16 +447,16 @@ class Economy(commands.Cog):
                     await self.change_credits(taker, give_count)
                     await self.change_credits(self.bot_discord_uid, tax_count)
                 else:
-                    await ctx.send(f'You only have {giver_total} credits!')
+                    await ctx.send(f'Transfer failed. You only have {helper.credits_to_string_with_exact_value(giver_total)}!')
             else:
                 await ctx.send(f'The flat transaction fee is 5 C!', delete_after=10)
 
     @transfer.error
     async def transfer_error(self, ctx, error):
         if isinstance(error, commands.MissingRequiredArgument):
-            await ctx.send('How many credits are you transferring?', delete_after=10)
+            await ctx.send('Please specify the amount to transfer.\nType "$help transfer" for more info.', delete_after=10)
         elif isinstance(error, commands.CommandOnCooldown):
-            await ctx.send('You are limited to 1 transfer per 30 seconds!', delete_after=5)
+            await ctx.send('You are limited to 1 transfer per 5 seconds!', delete_after=5)
         else:
             print(error)
 

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -1088,8 +1088,8 @@ class Economy(commands.Cog):
 
                 embed = discord.Embed(title='Deck Stats', description='')
                 embed.set_author(name=user.display_name, icon_url=user.avatar_url)
-                embed.add_field(name='Total cards', value=total_cards)
-                embed.add_field(name='Completion', value='{}/{}'.format(unique_cards, self.card_count))
+                embed.add_field(name='Total', value='{} cards'.format(total_cards), inline=False)
+                embed.add_field(name='Completion', value='{:.1f}% ({}/{})'.format(unique_cards / self.card_count * 100, unique_cards, self.card_count), inline=False)
                 embed.add_field(name='Value', value=f'{helper.credits_to_string(deck_value)}', inline=False)
                 embed.add_field(name='Affiliations', value='Heroes: {} ({}/{})\n'
                                                            'Neutrals: {} ({}/{})\n'

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -1826,9 +1826,15 @@ class SlotMachine:
         self.machine_type_names = cycle(list(self.machine_info_dict.keys()))
 
         # Set the iterator to the selected position
-        while self.selected_machine_name != next(self.machine_type_names):
-            pass
-        
+        machine_found = False
+        for i in range(0, self.machine_count):
+            if self.selected_machine_name == next(self.machine_type_names):
+                machine_found = True
+                break
+
+        if not machine_found:
+            self.selected_machine_name = next(self.machine_type_names)
+
         await self.setup_selected_machine()
         self.player_credits_total = await self.economy.get_credits(self.author.id)
         self.sent_embed = await self.ctx.send(embed=await self.generate_slot_embed())

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -2585,6 +2585,7 @@ class DeckStats:
         embed.add_field(name='Completion{} '.format(' ✅' if unique == max_unique else ''), 
             value='{:.1f}%\n{:,}/{:,}'.format(unique / max_unique * 100, unique, max_unique), inline=False)
         embed.add_field(name='Deck value', value='{}'.format(helper.credits_to_string_with_exact_value(deck_value, '\n')), inline=False)
+        embed.add_field(name='Average card value', value='{}'.format(helper.credits_to_string_with_exact_value(int(deck_value / total), '\n')), inline=False)
         embed.set_footer(text=f'Page 1/{len(self.pages)}')
         return embed        
 

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -1125,20 +1125,20 @@ class Economy(commands.Cog):
 
                 embed = discord.Embed(title='Deck Stats', description='')
                 embed.set_author(name=user.display_name, icon_url=user.avatar_url)
-                embed.add_field(name='Total', value='{} cards'.format(total_cards), inline=False)
-                embed.add_field(name='Completion', value='{:.1f}% ({}/{})'.format(unique_cards / self.card_count * 100, unique_cards, self.card_count), inline=False)
+                embed.add_field(name='Total', value='{:,} cards'.format(total_cards), inline=False)
+                embed.add_field(name='Completion', value='{:.1f}% ({:,}/{:,})'.format(unique_cards / self.card_count * 100, unique_cards, self.card_count), inline=False)
                 embed.add_field(name='Value', value=f'{helper.credits_to_string(deck_value)}', inline=False)
-                embed.add_field(name='Affiliations', value='Heroes: {} ({}/{})\n'
-                                                           'Neutrals: {} ({}/{})\n'
-                                                           'Villains: {} ({}/{})\n'
+                embed.add_field(name='Affiliations', value='Heroes: {:,} ({}/{})\n'
+                                                           'Neutrals: {:,} ({}/{})\n'
+                                                           'Villains: {:,} ({}/{})\n'
                     .format(total_affiliation_dict['Hero'], unique_affiliation_dict['Hero'], self.card_affiliation_count['Hero'],
                     total_affiliation_dict['Neutral'], unique_affiliation_dict['Neutral'], self.card_affiliation_count['Neutral'],
                     total_affiliation_dict['Villain'], unique_affiliation_dict['Villain'], self.card_affiliation_count['Villain']), inline=False)
-                embed.add_field(name='Rarity', value='Starters: {} ({}/{})\n'
-                                                     'Common: {} ({}/{})\n'
-                                                     'Uncommon: {} ({}/{})\n'
-                                                     'Rare: {} ({}/{})\n'
-                                                     'Legendary: {} ({}/{})'
+                embed.add_field(name='Rarity', value='Starters: {:,} ({}/{})\n'
+                                                     'Common: {:,} ({}/{})\n'
+                                                     'Uncommon: {:,} ({}/{})\n'
+                                                     'Rare: {:,} ({}/{})\n'
+                                                     'Legendary: {:,} ({}/{})'
                     .format(total_rarity_dict['S'], unique_rarity_dict['S'], self.card_rarity_count['S'],
                         total_rarity_dict['C'], unique_rarity_dict['C'], self.card_rarity_count['C'],
                         total_rarity_dict['U'], unique_rarity_dict['U'], self.card_rarity_count['U'],

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -1921,8 +1921,9 @@ class Shop:
         self.category_index = self.shop_category_list.index(self.selected_shop_category)
         self.selected_shop_dict = self.shop_dict.get(self.selected_shop_category)
         self.sent_embed = await self.ctx.send(embed=await self.generate_shop_embed())
-        for e in Shop.action_emoji_list:
-            await self.sent_embed.add_reaction(e)
+        if self.categories_max > 1:
+            for e in Shop.action_emoji_list:
+                await self.sent_embed.add_reaction(e)
 
     async def next_category(self, distance: int = 1):
         for _ in range(0, distance):

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -325,7 +325,7 @@ class Economy(commands.Cog):
         """Information on game"""
         rules = 'Competitive seasonal play where ranking is determined by final Galactic Imperial Points!' \
                 '\nPrizes: 1st - $20, 2nd - $10, 3rd - $5'
-        start = f'Send a message with the keyword "HOPE" in chat for {self.credit_msg_reward} credits every 30 mins from the Rebel Alliance!' \
+        start = f'Send a message with the keyword "HOPE" in chat for {helper.credits_to_string(self.credit_msg_reward)} every 30 mins from the Rebel Alliance!' \
                 '\nCheck out the other game commands with $help Economy'
         road_map = 'Inventory\nRPGAdventure'
         embed = discord.Embed(title='Game?', description='*Season 1: The Beginning*')
@@ -377,7 +377,7 @@ class Economy(commands.Cog):
             await ctx.send(embed=embed)
 
         else:
-            await ctx.send(f'Sorry, a credit lotto combo-pack costs {self.lotto_cost} C.', delete_after=15)
+            await ctx.send(f'Sorry, a credit lotto combo-pack costs {helper.credits_to_string(self.lotto_cost)}.', delete_after=15)
 
     @commands.command()
     async def bal(self, ctx, user: discord.Member = None):
@@ -486,6 +486,8 @@ class Economy(commands.Cog):
         Usage:
         $duel @user amount
 
+        Minimum amount is 100 C.
+
         Example:
         $duel @user 500
         $duel @user 10k
@@ -493,6 +495,10 @@ class Economy(commands.Cog):
         wager = 0
         try:
             wager = helper.parse_amount(amount)
+            if wager < 100:
+                await ctx.send('Invalid argument: Minimum amount is {}!'.format(helper.credits_to_string(100)))
+                return
+
         except ValueError:
             await ctx.send('Invalid argument: {}\nType "$help duel" for more info.'.format(amount))
             return

--- a/gonk_droid.py
+++ b/gonk_droid.py
@@ -35,13 +35,13 @@ client = commands.Bot(command_prefix='$', description=description, intents=inten
 @client.event
 async def on_ready():
     """Startup Messages"""
-    print('------')
-    print(f'Logged in as {client.user.name}')
-    print(f'Discord.py API version: {discord.__version__}')
-    print(f'Python version: {platform.python_version()}')
-    print(f'Interpretor: {sys.executable}')
-    print(f'Running on: {platform.system()} {platform.release()} ({os.name})')
-    print('------')
+    await helper.bot_log(client, '------'
+                f'\nLogged in as {client.user.name}'
+                f'\nDiscord.py API version: {discord.__version__}'
+                f'\nPython version: {platform.python_version()}'
+                f'\nInterpretor: {sys.executable}'
+                f'\nRunning on: {platform.system()} {platform.release()} ({os.name})'
+                '\n------')
     activity = discord.Activity(name='Jizz Droid', type=discord.ActivityType.listening)
     await client.change_presence(status=discord.Status.online, activity=activity)
     await load_all()
@@ -117,7 +117,7 @@ async def load_error(ctx, error):
     elif isinstance(error, commands.MissingRequiredArgument):
         await ctx.send('Missing target cog parameter')
     else:
-        print(error)
+        await helper.bot_log(client, error)
 
 
 @client.command()
@@ -149,7 +149,7 @@ async def unload_error(ctx, error):
     elif isinstance(error, commands.MissingRequiredArgument):
         await ctx.send('Missing target cog parameter')
     else:
-        print(error)
+        await helper.bot_log(client, error)
 
 
 @client.command()
@@ -183,7 +183,7 @@ async def reload_error(ctx, error):
     elif isinstance(error, commands.MissingRequiredArgument):
         await ctx.send('Missing target cog parameter')
     else:
-        print(error)
+        await helper.bot_log(client, error)
 # endregion
 
 

--- a/utils/helper.py
+++ b/utils/helper.py
@@ -99,7 +99,7 @@ async def parse_input_args_filters(ctx, commands, args) -> (discord.Member, bool
     """Parses the args looking for Discord user, "all", affiliation, rarity and card codes"""
     user = None
     has_all = False
-    affiliation_codes = []
+    affiliation_names = []
     rarity_codes = []
     card_codes = []
 
@@ -115,11 +115,11 @@ async def parse_input_args_filters(ctx, commands, args) -> (discord.Member, bool
             if argLowerCase == 'all':
                 has_all = True
             elif argLowerCase in ['v', 'villain', 'villains']:
-                affiliation_codes.append('villain')
+                affiliation_names.append('Villain')
             elif argLowerCase in ['h', 'hero', 'heroes']:
-                affiliation_codes.append('hero')
+                affiliation_names.append('Hero')
             elif argLowerCase in ['n', 'neutral', 'neutrals']:
-                affiliation_codes.append('neutral')
+                affiliation_names.append('Neutral')
             elif argLowerCase in ['s', 'starter', 'starters']:
                 rarity_codes.append('S')
             elif argLowerCase in ['c', 'common']:
@@ -135,12 +135,12 @@ async def parse_input_args_filters(ctx, commands, args) -> (discord.Member, bool
             else:
                 raise ValueError('Invalid argument: {}'.format(arg))
 
-    if card_codes and (has_all or affiliation_codes or rarity_codes):
+    if card_codes and (has_all or affiliation_names or rarity_codes):
         raise ValueError('Invalid arguments. You can\'t mix card numbers and batch.')
-    elif has_all and (affiliation_codes or rarity_codes):
+    elif has_all and (affiliation_names or rarity_codes):
         raise ValueError('Invalid arguments. Use either \"all\" or affiliation/rarity name but not both.')
 
-    return user, has_all, affiliation_codes, rarity_codes, card_codes
+    return user, has_all, affiliation_names, rarity_codes, card_codes
 
 def parse_amount(amount: str) -> int:
     """Parses the amount that can be either and integer, or something like "10k", "1.2M", etc..."""

--- a/utils/helper.py
+++ b/utils/helper.py
@@ -212,3 +212,22 @@ def credits_to_string_with_exact_value(amount: int, separator: str = ' ', signif
         return '{}{}({:,} C)'.format(credits_to_string(amount), separator, amount)
     else:
         return '{:,} C'.format(amount)
+
+async def bot_log(client: discord.client, error: str, message: discord.Message = None):
+    # Print the error in the console, then in #bot-log channel if it exists
+    error_message = '{}{}'.format(
+            '{} in #{}: "{}": '.format(
+                message.author.display_name, 
+                message.channel,
+                message.content) if message is not None else '', 
+            error);
+
+    # Console
+    print(error_message)
+
+    # Discord channel
+    channel_name = 'bot-log'
+    guild = client.get_guild(get_config('guild_id'))
+    log_channel = discord.utils.get(guild.text_channels, name=channel_name)
+    if log_channel:
+        await log_channel.send(error_message)

--- a/utils/helper.py
+++ b/utils/helper.py
@@ -1,5 +1,6 @@
 import json
 import discord
+import math
 
 
 def get_config(key):
@@ -162,10 +163,11 @@ def parse_amount(amount: str) -> int:
     else:
         return int(float(amount[:len(amount)-1])*10**exp)
 
-def credits_to_string(amount: int) -> str:
+def credits_to_string(amount: int, significant_numbers: int = 3) -> str:
     letter = ''
     divider = 1
     absAmount = abs(amount)
+
     if absAmount >= 10**15:
         letter = 'Q'
         divider = 10**15
@@ -184,4 +186,8 @@ def credits_to_string(amount: int) -> str:
     if amount >= 10**18:
         return '{:,} {}C'.format(int(amount / divider), letter)
     else:
-        return '{:.3g} {}C'.format(amount / divider, letter)
+        power_of_10 = max(0,int(math.floor(math.log10(absAmount))))
+        precision = significant_numbers - 1 - (power_of_10 % 3)
+        return '{1:.{0}f} {2}C'.format(precision,
+            math.floor(amount / 10**(power_of_10 - significant_numbers + 1)) / 10**precision, 
+            letter)

--- a/utils/helper.py
+++ b/utils/helper.py
@@ -79,6 +79,10 @@ def join_with_and(values, last_word: str = 'and') -> str:
     # Empty
     return ''
 
+def join_with_or(values) -> str:
+    """Same as ', '.join() but with ' and ' between the last 2 values"""
+    return join_with_and(values, 'or')
+
 def is_valid_card_number_format(s: str) -> bool:
     # Between 5 and 7 digits, can have a letter at the end
     length = len(s)
@@ -96,10 +100,11 @@ def is_valid_card_number_format(s: str) -> bool:
     else:
         return False
 
-async def parse_input_args_filters(ctx, commands, args) -> (discord.Member, bool, list, list, list):
+async def parse_input_args_filters(ctx, commands, args) -> (discord.Member, bool, str, list, list, list):
     """Parses the args looking for Discord user, "all", affiliation, rarity and card codes"""
     user = None
     has_all = False
+    group_by_key = 'set_code'
     affiliation_names = []
     rarity_codes = []
     card_codes = []
@@ -115,6 +120,14 @@ async def parse_input_args_filters(ctx, commands, args) -> (discord.Member, bool
             argLowerCase = arg.lower()
             if argLowerCase == 'all':
                 has_all = True
+            elif argLowerCase in ['a', 'affiliation', 'affiliations']:
+                group_by_key = 'affiliation_name'
+            elif argLowerCase in ['f', 'faction', 'factions']:
+                group_by_key = 'faction_name'
+            elif argLowerCase in ['rar', 'rarity']:
+                group_by_key = 'rarity_code'
+            elif argLowerCase in ['nogroup', 'nogroups']:
+                group_by_key = ''
             elif argLowerCase in ['v', 'villain', 'villains']:
                 affiliation_names.append('Villain')
             elif argLowerCase in ['h', 'hero', 'heroes']:
@@ -141,7 +154,7 @@ async def parse_input_args_filters(ctx, commands, args) -> (discord.Member, bool
     elif has_all and (affiliation_names or rarity_codes):
         raise ValueError('Invalid arguments. Use either \"all\" or affiliation/rarity name but not both.')
 
-    return user, has_all, affiliation_names, rarity_codes, card_codes
+    return user, has_all, group_by_key, affiliation_names, rarity_codes, card_codes
 
 def parse_amount(amount: str) -> int:
     """Parses the amount that can be either and integer, or something like "10k", "1.2M", etc..."""

--- a/utils/helper.py
+++ b/utils/helper.py
@@ -61,17 +61,17 @@ def record_to_dict(f_record, key_name: str):
                     return_dict[key] = {f: v}
     return return_dict
 
-def join_with_and(values) -> str:
+def join_with_and(values, last_word: str = 'and') -> str:
     """Same as ', '.join() but with ' and ' between the last 2 values"""
     valuesList = list(values)
     length = len(valuesList)
 
     # value1, value2, value3 and value4
     if length > 2:
-        return ', '.join(valuesList[:-1]) + " and " + str(valuesList[-1])
+        return '{} {} {}'.format(', '.join(valuesList[:-1]), last_word, valuesList[-1])
     # value1 and value2
     elif length == 2:
-        return ' and '.join(valuesList)
+        return '{} {} {}'.format(valuesList[0], last_word, valuesList[1])
     # value 1
     elif length == 1:
         return valuesList[0]

--- a/utils/helper.py
+++ b/utils/helper.py
@@ -214,7 +214,7 @@ def credits_to_string_with_exact_value(amount: int, separator: str = ' ', signif
         return '{:,} C'.format(amount)
 
 async def bot_log(client: discord.client, error: str, message: discord.Message = None):
-    # Print the error in the console, then in #bot-log channel if it exists
+    # Print the error in the console, then in #bot-logs channel if it exists
     error_message = '{}{}'.format(
             '{} in #{}: "{}": '.format(
                 message.author.display_name, 
@@ -226,7 +226,7 @@ async def bot_log(client: discord.client, error: str, message: discord.Message =
     print(error_message)
 
     # Discord channel
-    channel_name = 'bot-log'
+    channel_name = 'bot-logs'
     guild = client.get_guild(get_config('guild_id'))
     log_channel = discord.utils.get(guild.text_channels, name=channel_name)
     if log_channel:

--- a/utils/helper.py
+++ b/utils/helper.py
@@ -164,6 +164,7 @@ def parse_amount(amount: str) -> int:
         return int(float(amount[:len(amount)-1])*10**exp)
 
 def credits_to_string(amount: int, significant_numbers: int = 3) -> str:
+    """Returns "XXX'XXX" C if under a million, otherwise "XXX MC" """
     letter = ''
     divider = 1
     absAmount = abs(amount)
@@ -191,3 +192,10 @@ def credits_to_string(amount: int, significant_numbers: int = 3) -> str:
         return '{1:.{0}f} {2}C'.format(precision,
             math.floor(amount / 10**(power_of_10 - significant_numbers + 1)) / 10**precision, 
             letter)
+
+def credits_to_string_with_exact_value(amount: int, separator: str = ' ', significant_numbers: int = 3) -> str:
+    """Returns "XXX'XXX" C if under a million, otherwise "XXX MC (XXX'XXX'XXX C)" """
+    if amount >= 10**6:
+        return '{}{}({:,} C)'.format(credits_to_string(amount), separator, amount)
+    else:
+        return '{:,} C'.format(amount)


### PR DESCRIPTION
Changelog:
Global fixes:
- Fixed crashes from previous update for $deck, $deck_stats, $send_card and $request_card commands
- Fixed flooring of money amount display

$buy command:
- Added embed with purchased items, total cost, cards value, cards bonus and amount left in wallet
- Added '👁' emoji to show directly the cards you bought in a deck view

$deck command:
- Added Group By arguments to group the cards either by rarity, affiliation, faction or in one list.
- Card bonus is displayed as "+0.20x" instead of "+20%" which matches what's displayed on the slot machine
- Reworked the header to display the card name and quantity if bigger than 1
- Footer will show you who has the card you're looking for if you're using "$deck missing"

$deck_stats command:
- Displays stats on 5 pages: Global, Rarity, Affiliation, Faction and Set

$transfer command:
- Displays rounded and exact amounts in messages
- Cooldown reduced to 5s

$shop command:
- Removed navigation emoji if there are only one category
- Added wallet amount

$bal command:
- Show both rounded and exact amounts

Note:
I've also added an error handling for all the Economy commands that prints errors not only on the console but also on a #bot-log channel if it exists. Would be nice if you can create one on Gray Discord and give me read access :-)
Errors look like this:
[FO-044] MegadetH in #general: "$deck missing v l": Command raised an exception: NameError: name 'card_list' is not defined
